### PR TITLE
Fixing typeError inside _registerCheckoutSubmitButton()

### DIFF
--- a/src/Resources/app/storefront/src/helper/buckaroo-validate.js
+++ b/src/Resources/app/storefront/src/helper/buckaroo-validate.js
@@ -11,9 +11,10 @@ export default class BuckarooPaymentValidateSubmit extends Plugin {
         }
     }
     _registerCheckoutSubmitButton() {
-        const editButton = document.getElementById('confirmOrderForm').querySelector('[type="submit"]');
-        if (editButton) {
-            editButton.addEventListener('click', this._handleCheckoutSubmit.bind(this));
+        const confirmOrderForm = document.getElementById('confirmOrderForm')
+        if (confirmOrderForm) {
+            const submitButton = confirmOrderForm.querySelector('[type="submit"]');
+            submitButton.addEventListener('click', this._handleCheckoutSubmit.bind(this));
         }
     }
     _handleCheckoutSubmit(e) {


### PR DESCRIPTION
Inside the `_registerCheckoutSubmitButton()` function there is a check for a `editButton`. This caused a typeError because the `confirmOrderForm` is only present on the checkout page. Because the plugin script is bundled together with custom javascript from themes this caused the javascript to break for the frontend:

```
init error TypeError: Cannot read properties of null (reading 'querySelector')
    at BuckarooPaymentValidateSubmit._registerCheckoutSubmitButton (buckaroo-validate.js?85a1:14:1)
    at BuckarooPaymentValidateSubmit.init (buckaroo-validate.js?85a1:7:1)
    at BuckarooPaymentValidateSubmit._init (plugin.class.js?1462:56:1)
    at BuckarooPaymentValidateSubmit.Plugin (plugin.class.js?1462:29:1)
    at new BuckarooPaymentValidateSubmit (buckaroo-validate.js?85a1:3:1)
    at Function._initializePluginOnElement (plugin.manager.js?0b18:293:1)
    at PluginManagerSingleton._initializePlugin (plugin.manager.js?0b18:265:1)
    at eval (plugin.manager.js?0b18:215:1)
    at Map.forEach (<anonymous>)
    at Function.iterate (iterator.helper.js?1116:20:1)
```

I changed the `_registerCheckoutSubmitButton()` to check for the form first, before trying to bind the `_handleCheckoutSubmit` function. I also changed `editButton` to `submitButton` since it seemed more appropriate for the target element.
